### PR TITLE
feat: back buttons

### DIFF
--- a/src/app/(protected)/workspace/[namespace]/hardware/[hardwareId]/page.tsx
+++ b/src/app/(protected)/workspace/[namespace]/hardware/[hardwareId]/page.tsx
@@ -7,11 +7,14 @@ import { Separator } from "~/components/ui/separator";
 
 import { api } from "~/trpc/server";
 import HardwareMeasurements from "./_components/hardware-measurements";
+import BackButton from "~/components/back-button";
 
 export default async function Hardware({
   params,
+  searchParams,
 }: {
   params: { hardwareId: string; namespace: string };
+  searchParams: { back?: string };
 }) {
   const device = await api.hardware.getHardwareById.query({
     hardwareId: params.hardwareId,
@@ -25,6 +28,7 @@ export default async function Hardware({
   return (
     <div className="container max-w-screen-2xl">
       <PageHeader>
+        {searchParams.back && <BackButton />}
         <PageHeaderHeading className="">{device.name}</PageHeaderHeading>
         <PageHeaderDescription>
           All tests that have been performed on "{device.name}" are listed here.

--- a/src/app/(protected)/workspace/[namespace]/hardware/page.tsx
+++ b/src/app/(protected)/workspace/[namespace]/hardware/page.tsx
@@ -7,11 +7,14 @@ import { api } from "~/trpc/server";
 import HardwareInstances from "./_components/hardware-instances";
 import HardwareModels from "./_components/hardware-models";
 import { Separator } from "~/components/ui/separator";
+import { Button } from "~/components/ui/button";
 
 export default async function HardwareInventory({
   params,
+  searchParams,
 }: {
   params: { namespace: string };
+  searchParams: { back?: string };
 }) {
   const workspaceId = await api.workspace.getWorkspaceIdByNamespace.query({
     namespace: params.namespace,
@@ -33,6 +36,7 @@ export default async function HardwareInventory({
 
   return (
     <div className="container max-w-screen-2xl">
+      {searchParams.back && <Button>Back</Button>}
       <PageHeader>
         <PageHeaderHeading>Hardware Inventory</PageHeaderHeading>
         <PageHeaderDescription>

--- a/src/app/(protected)/workspace/[namespace]/measurement/[measurementId]/page.tsx
+++ b/src/app/(protected)/workspace/[namespace]/measurement/[measurementId]/page.tsx
@@ -1,5 +1,13 @@
 import Link from "next/link";
+import BackButton from "~/components/back-button";
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderHeading,
+} from "~/components/small-header";
+import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
+import { Separator } from "~/components/ui/separator";
 import DataframeViz from "~/components/visualization/dataframe-viz";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/server";
@@ -26,8 +34,10 @@ const BooleanViz = ({ data }: BooleanVizProps) => {
 
 export default async function Measurement({
   params,
+  searchParams,
 }: {
   params: { measurementId: string; namespace: string };
+  searchParams: { back?: string };
 }) {
   const measurement = await api.measurement.getMeasurementById.query({
     measurementId: params.measurementId,
@@ -55,21 +65,25 @@ export default async function Measurement({
 
   return (
     <div className="container max-w-screen-2xl">
-      <div className="py-4"></div>
-      <h1 className="text-3xl font-bold">{measurement.name}</h1>
-      <div className="text-base text-muted-foreground">
-        {params.measurementId}
-      </div>
-      <div className="py-2" />
-      <div className="text-muted-foreground">
-        {measurement.createdAt.toString()}
-      </div>
-      <Link
-        className="text-lg"
-        href={`/workspace/${params.namespace}/device/${measurement.hardware.id}`}
-      >
-        {measurement.hardware.name}
-      </Link>
+      <PageHeader>
+        {searchParams.back && <BackButton />}
+
+        <PageHeaderHeading className="">{measurement.name}</PageHeaderHeading>
+        <PageHeaderDescription>
+          {measurement.createdAt.toString()}
+        </PageHeaderDescription>
+      </PageHeader>
+
+      <Separator className="my-6" />
+
+      <Button asChild>
+        <Link
+          href={`/workspace/${params.namespace}/hardware/${measurement.hardware.id}`}
+        >
+          {measurement.hardware.model.name} {measurement.hardware.name}
+        </Link>
+      </Button>
+
       <div className="py-4" />
       {visualization}
     </div>

--- a/src/app/(protected)/workspace/[namespace]/measurement/[measurementId]/page.tsx
+++ b/src/app/(protected)/workspace/[namespace]/measurement/[measurementId]/page.tsx
@@ -5,7 +5,7 @@ import {
   PageHeaderDescription,
   PageHeaderHeading,
 } from "~/components/small-header";
-import { Button } from "~/components/ui/button";
+import { Badge } from "~/components/ui/badge";
 import { Card } from "~/components/ui/card";
 import { Separator } from "~/components/ui/separator";
 import DataframeViz from "~/components/visualization/dataframe-viz";
@@ -69,20 +69,24 @@ export default async function Measurement({
         {searchParams.back && <BackButton />}
 
         <PageHeaderHeading className="">{measurement.name}</PageHeaderHeading>
-        <PageHeaderDescription>
-          {measurement.createdAt.toString()}
-        </PageHeaderDescription>
+        <PageHeaderDescription>{measurement.id}</PageHeaderDescription>
       </PageHeader>
 
       <Separator className="my-6" />
 
-      <Button asChild>
-        <Link
-          href={`/workspace/${params.namespace}/hardware/${measurement.hardware.id}`}
-        >
-          {measurement.hardware.model.name} {measurement.hardware.name}
-        </Link>
-      </Button>
+      <div>
+        <div>Taken at: {measurement.createdAt.toString()}</div>
+        <div>
+          Hardware instance:{" "}
+          <Badge>
+            <Link
+              href={`/workspace/${params.namespace}/hardware/${measurement.hardware.id}`}
+            >
+              {measurement.hardware.model.name} {measurement.hardware.name}
+            </Link>
+          </Badge>
+        </div>
+      </div>
 
       <div className="py-4" />
       {visualization}

--- a/src/app/(protected)/workspace/[namespace]/project/[projectId]/hardwares/_components/device-card.tsx
+++ b/src/app/(protected)/workspace/[namespace]/project/[projectId]/hardwares/_components/device-card.tsx
@@ -24,7 +24,14 @@ const HardwareCard = ({ hardware, namespace }: Props) => {
   return (
     <ContextMenu>
       <ContextMenuTrigger>
-        <Link href={`/workspace/${namespace}/hardware/${hardware.id}`}>
+        <Link
+          href={{
+            pathname: `/workspace/${namespace}/hardware/${hardware.id}`,
+            query: {
+              back: true,
+            },
+          }}
+        >
           <Card className="transition-all duration-300 hover:bg-secondary/80">
             <CardHeader>
               <CardTitle>{hardware.name}</CardTitle>

--- a/src/app/(protected)/workspace/[namespace]/project/[projectId]/tests/_components/test-card.tsx
+++ b/src/app/(protected)/workspace/[namespace]/project/[projectId]/tests/_components/test-card.tsx
@@ -26,7 +26,12 @@ const TestCard = ({ test, namespace }: Props) => {
   return (
     <ContextMenu>
       <ContextMenuTrigger>
-        <Link href={`/workspace/${namespace}/test/${test.id}`}>
+        <Link
+          href={{
+            pathname: `/workspace/${namespace}/test/${test.id}`,
+            query: { back: true },
+          }}
+        >
           <Card className="transition-all duration-300 hover:bg-secondary/80">
             <CardHeader>
               <CardTitle>{test.name}</CardTitle>

--- a/src/app/(protected)/workspace/[namespace]/test/[testId]/page.tsx
+++ b/src/app/(protected)/workspace/[namespace]/test/[testId]/page.tsx
@@ -6,11 +6,14 @@ import {
 } from "~/components/small-header";
 import { api } from "~/trpc/server";
 import { Separator } from "~/components/ui/separator";
+import BackButton from "~/components/back-button";
 
 export default async function Test({
   params,
+  searchParams,
 }: {
   params: { testId: string; namespace: string };
+  searchParams: { back?: string };
 }) {
   const test = await api.test.getTestById.query({
     testId: params.testId,
@@ -23,6 +26,8 @@ export default async function Test({
   return (
     <div className="container max-w-screen-2xl">
       <PageHeader>
+        {searchParams.back && <BackButton />}
+
         <PageHeaderHeading className="">{test.name}</PageHeaderHeading>
         <PageHeaderDescription>
           All measurements for the "{test.name}" test are listed here.

--- a/src/components/back-button.tsx
+++ b/src/components/back-button.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "./ui/button";
+import { ChevronsLeft } from "lucide-react";
+
+const BackButton = () => {
+  const router = useRouter();
+  return (
+    <Button onClick={() => router.back()} variant="secondary">
+      <ChevronsLeft className="mr-2" />
+      Back
+    </Button>
+  );
+};
+
+export default BackButton;

--- a/src/components/measurements-data-table.tsx
+++ b/src/components/measurements-data-table.tsx
@@ -18,7 +18,7 @@ export function MeasurementsDataTable({ measurements, namespace }: Props) {
       columns={columns}
       data={measurements}
       onRowClick={(row) =>
-        router.push(`/workspace/${namespace}/measurement/${row.id}`)
+        router.push(`/workspace/${namespace}/measurement/${row.id}?back=true`)
       }
     />
   );


### PR DESCRIPTION
![CleanShot 2024-02-01 at 18 30 29@2x](https://github.com/flojoy-ai/cloud/assets/25695219/cc4c9072-f04e-4217-984f-240ed6166f6e)

To enable this back button, you need to set the query param `back=true`

![CleanShot 2024-02-01 at 18 31 02](https://github.com/flojoy-ai/cloud/assets/25695219/e6dc45e5-daa3-4d15-ab9a-fc532dc712bc)

Resolves CLO-48 as well
