### PR TITLE
Adding test sequencer export

### DIFF
--- a/sdks/python/flojoy-cloud/flojoy_cloud/__init__.py
+++ b/sdks/python/flojoy-cloud/flojoy_cloud/__init__.py
@@ -1,3 +1,4 @@
 from flojoy_cloud.client import FlojoyCloud  # noqa
 from flojoy_cloud.dtypes import *  # noqa
 from flojoy_cloud.measurement import MeasurementData  # noqa
+from flojoy_cloud.test_sequencer import *  # noqa

--- a/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
+++ b/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
@@ -9,7 +9,7 @@ from .measurement import MeasurementData
 
 __all__ = [
     "export",
-    "get_most_recent_data",
+    "_get_most_recent_data",
     "_set_output_loc",
 ]
 
@@ -34,7 +34,10 @@ def export(data: MeasurementData):
         raise TypeError(f"Unsupported data type: {type(data)}")
 
 
-def get_most_recent_data(
+# ------ Protected ------
+
+
+def _get_most_recent_data(
     test_id: str | None, rm_file: bool = False
 ) -> MeasurementData | None:
     """

--- a/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
+++ b/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
@@ -43,7 +43,8 @@ def get_most_recent_data(
         - test_id (str | None): The prefix used to find the data files. If None, the default prefix is used.
         - rm_file (bool): If True, the file is removed after being read.
     """
-    _set_output_loc(test_id)
+    if test_id is not None:
+        _set_output_loc(test_id)
 
     output_dir, prefix_file = __get_location()
     output_file = __get_most_recent_file(output_dir, prefix_file)
@@ -55,9 +56,6 @@ def get_most_recent_data(
         os.remove(output_dir + output_file)
 
     return __extract_data(output_dir + output_file)
-
-
-# ------ Protected ------
 
 
 def _set_output_loc(prefix: str | None):
@@ -119,4 +117,4 @@ def __extract_data(path: str):
         return int(open(path, "r").read())
     if path.endswith(FLOAT):
         return float(open(path, "r").read())
-    raise ValueError("Unknown file type")
+    raise TypeError("Unknown file type")

--- a/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
+++ b/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
@@ -1,0 +1,122 @@
+import logging
+import os
+import pandas as pd
+import tempfile
+from .measurement import MeasurementData
+
+
+# ------ Public ------
+
+__all__ = [
+    "export",
+    "get_most_recent_data",
+    "_set_output_loc",
+]
+
+
+def export(data: MeasurementData):
+    """Export data so it can be retrieved by the test sequencer"""
+    output_dir, prefix_file = __get_location()
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    elif isinstance(data, pd.DataFrame):
+        data.to_csv(os.path.join(output_dir, prefix_file + DATAFRAME))
+    elif isinstance(data, bool):
+        with open(os.path.join(output_dir, prefix_file + BOOLEAN), "w") as f:
+            f.write(str(data))
+    elif isinstance(data, int):
+        with open(os.path.join(output_dir, prefix_file + INT), "w") as f:
+            f.write(str(data))
+    elif isinstance(data, float):
+        with open(os.path.join(output_dir, prefix_file + FLOAT), "w") as f:
+            f.write(str(data))
+    else:
+        raise TypeError(f"Unsupported data type: {type(data)}")
+
+
+def get_most_recent_data(
+    test_id: str | None, rm_file: bool = False
+) -> MeasurementData | None:
+    """
+    Retrieves the most recent data produced in a test run from within the test sequencer.
+    Parameters:
+        - test_id (str | None): The prefix used to find the data files. If None, the default prefix is used.
+        - rm_file (bool): If True, the file is removed after being read.
+    """
+    _set_output_loc(test_id)
+
+    output_dir, prefix_file = __get_location()
+    output_file = __get_most_recent_file(output_dir, prefix_file)
+
+    if output_file is None:
+        return None
+
+    if rm_file:
+        os.remove(output_dir + output_file)
+
+    return __extract_data(output_dir + output_file)
+
+
+# ------ Protected ------
+
+
+def _set_output_loc(prefix: str | None):
+    """Set the output location for the data when launching a test in the test sequencer."""
+    if prefix is not None:
+        os.environ[OPTIONAL_NAME_ENV] = prefix
+    else:
+        os.environ.pop(OPTIONAL_NAME_ENV)
+
+
+# ------ Private ------
+
+
+DEFAULT_PATH = os.path.join(tempfile.gettempdir(), "flojoy/")
+OPTIONAL_PATH_ENV = "FLOJOY_DATA_PATH"
+DEFAULT_NAME = "output"
+OPTIONAL_NAME_ENV = "FLOJOY_DATA_NAME"
+
+DATAFRAME = "_dataframe.csv"
+BOOLEAN = "_boolean.txt"
+INT = "_int.txt"
+FLOAT = "_float.txt"
+
+
+def __get_location():
+    output_dir = os.environ.get(OPTIONAL_PATH_ENV)
+    prefix_file = os.environ.get(OPTIONAL_NAME_ENV)
+    if output_dir is None:
+        output_dir = DEFAULT_PATH
+    if prefix_file is None:
+        prefix_file = DEFAULT_NAME
+
+    return output_dir, prefix_file
+
+
+def __get_most_recent_file(output_dir: str, prefix_file: str):
+    most_recent_file = None
+    most_recent_time = 0
+    for file in os.listdir(output_dir):
+        logging.info(f"Available data: {file}")
+        if file.startswith(prefix_file):
+            file_path = os.path.join(output_dir, file)
+            file_time = os.path.getmtime(file_path)
+            if file_time > most_recent_time:
+                most_recent_time = file_time
+                most_recent_file = file
+
+    return most_recent_file
+
+
+def __extract_data(path: str):
+    if path.endswith(DATAFRAME):
+        return pd.read_csv(path, index_col=0)
+    if path.endswith(BOOLEAN):
+        with open(path, "r") as f:
+            str_bool = f.read().strip().lower()
+            return str_bool == "true" or str_bool == "1"
+    if path.endswith(INT):
+        return int(open(path, "r").read())
+    if path.endswith(FLOAT):
+        return float(open(path, "r").read())
+    raise ValueError("Unknown file type")

--- a/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
+++ b/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
@@ -84,10 +84,8 @@ FLOAT = "_float.txt"
 
 
 def __get_location():
-    output_dir = os.environ.get(OPTIONAL_PATH_ENV)
+    output_dir = DEFAULT_PATH
     prefix_file = os.environ.get(OPTIONAL_NAME_ENV)
-    if output_dir is None:
-        output_dir = DEFAULT_PATH
     if prefix_file is None:
         prefix_file = DEFAULT_NAME
 

--- a/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
+++ b/sdks/python/flojoy-cloud/flojoy_cloud/test_sequencer.py
@@ -19,7 +19,7 @@ def export(data: MeasurementData):
     output_dir, prefix_file = __get_location()
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    elif isinstance(data, pd.DataFrame):
+    if isinstance(data, pd.DataFrame):
         data.to_csv(os.path.join(output_dir, prefix_file + DATAFRAME))
     elif isinstance(data, bool):
         with open(os.path.join(output_dir, prefix_file + BOOLEAN), "w") as f:

--- a/sdks/python/flojoy-cloud/tests/sequencer_export_test.py
+++ b/sdks/python/flojoy-cloud/tests/sequencer_export_test.py
@@ -13,7 +13,8 @@ def test_set_output():
     test_sequencer.export(my_value)
 
     # Change the output to default
-    test_sequencer._set_output_loc(None)
+    new_test_id = f"my_test_id_{randint(1001,2000)}"
+    test_sequencer._set_output_loc(new_test_id)
     my_new_value = randint(0, 1000)
     test_sequencer.export(my_new_value)
 
@@ -21,7 +22,7 @@ def test_set_output():
     data = test_sequencer.get_most_recent_data(test_id)
     assert data == my_value
 
-    data = test_sequencer.get_most_recent_data(None)
+    data = test_sequencer.get_most_recent_data(new_test_id)
     assert data == my_new_value
 
 
@@ -50,7 +51,7 @@ def test_export_dataframe():
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     test_sequencer.export(df)
     # Verify that the lastest data is the only one retreive
-    data: pd.DataFrame = test_sequencer.get_most_recent_data(test_id)  # type: ignore
+    data: pd.DataFrame = test_sequencer._get_most_recent_data(test_id)  # type: ignore
     assert data.equals(df)
 
 

--- a/sdks/python/flojoy-cloud/tests/sequencer_export_test.py
+++ b/sdks/python/flojoy-cloud/tests/sequencer_export_test.py
@@ -1,0 +1,84 @@
+from flojoy_cloud import test_sequencer
+from random import randint, random
+import pandas as pd
+
+
+def test_set_output():
+    # Set the output location to simulate a test run in the test sequencer
+    test_id = f"my_test_id_{randint(0,1000)}"
+    test_sequencer._set_output_loc(test_id)
+
+    # Simulate user export
+    my_value = randint(0, 1000)
+    test_sequencer.export(my_value)
+
+    # Change the output to default
+    test_sequencer._set_output_loc(None)
+    my_new_value = randint(0, 1000)
+    test_sequencer.export(my_new_value)
+
+    # Verify nothing was been lost
+    data = test_sequencer.get_most_recent_data(test_id)
+    assert data == my_value
+
+    data = test_sequencer.get_most_recent_data(None)
+    assert data == my_new_value
+
+
+def test_multiple_data_export():
+    """Only the lastest should be retreive"""
+    test_id = f"my_test_id_{randint(0,1000)}"
+    test_sequencer._set_output_loc(test_id)
+
+    # Simulate user export
+    my_value = randint(0, 1000)
+    test_sequencer.export(my_value)
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    test_sequencer.export(df)
+    my_new_value = randint(0, 1000)
+    test_sequencer.export(my_new_value)
+
+    # Verify that the lastest data is the only one retreive
+    data = test_sequencer.get_most_recent_data(test_id)
+    assert data == my_new_value
+
+
+def test_export_dataframe():
+    test_id = f"my_test_id_{randint(0,1000)}"
+    test_sequencer._set_output_loc(test_id)
+    # Simulate user export
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    test_sequencer.export(df)
+    # Verify that the lastest data is the only one retreive
+    data: pd.DataFrame = test_sequencer.get_most_recent_data(test_id)  # type: ignore
+    assert data.equals(df)
+
+
+def test_export_bool():
+    test_id = f"my_test_id_{randint(0,1000)}"
+    test_sequencer._set_output_loc(test_id)
+    # Simulate user export
+    test_sequencer.export(True)
+    # Verify that the lastest data is the only one retreive
+    data = test_sequencer.get_most_recent_data(test_id)
+    assert data is True
+
+
+def test_export_int():
+    test_id = f"my_test_id_{randint(0,1000)}"
+    test_sequencer._set_output_loc(test_id)
+    # Simulate user export
+    test_sequencer.export(1)
+    # Verify that the lastest data is the only one retreive
+    data = test_sequencer.get_most_recent_data(test_id)
+    assert data == 1
+
+
+def test_export_float():
+    test_id = f"my_test_id_{random()}"
+    test_sequencer._set_output_loc(test_id)
+    # Simulate user export
+    test_sequencer.export(1.0)
+    # Verify that the lastest data is the only one retreive
+    data = test_sequencer.get_most_recent_data(test_id)
+    assert data == 1.0

--- a/sdks/python/flojoy-cloud/tests/sequencer_export_test.py
+++ b/sdks/python/flojoy-cloud/tests/sequencer_export_test.py
@@ -19,10 +19,10 @@ def test_set_output():
     test_sequencer.export(my_new_value)
 
     # Verify nothing was been lost
-    data = test_sequencer.get_most_recent_data(test_id)
+    data = test_sequencer._get_most_recent_data(test_id)
     assert data == my_value
 
-    data = test_sequencer.get_most_recent_data(new_test_id)
+    data = test_sequencer._get_most_recent_data(new_test_id)
     assert data == my_new_value
 
 
@@ -40,7 +40,7 @@ def test_multiple_data_export():
     test_sequencer.export(my_new_value)
 
     # Verify that the lastest data is the only one retreive
-    data = test_sequencer.get_most_recent_data(test_id)
+    data = test_sequencer._get_most_recent_data(test_id)
     assert data == my_new_value
 
 
@@ -61,7 +61,7 @@ def test_export_bool():
     # Simulate user export
     test_sequencer.export(True)
     # Verify that the lastest data is the only one retreive
-    data = test_sequencer.get_most_recent_data(test_id)
+    data = test_sequencer._get_most_recent_data(test_id)
     assert data is True
 
 
@@ -71,7 +71,7 @@ def test_export_int():
     # Simulate user export
     test_sequencer.export(1)
     # Verify that the lastest data is the only one retreive
-    data = test_sequencer.get_most_recent_data(test_id)
+    data = test_sequencer._get_most_recent_data(test_id)
     assert data == 1
 
 
@@ -81,5 +81,5 @@ def test_export_float():
     # Simulate user export
     test_sequencer.export(1.0)
     # Verify that the lastest data is the only one retreive
-    data = test_sequencer.get_most_recent_data(test_id)
+    data = test_sequencer._get_most_recent_data(test_id)
     assert data == 1.0


### PR DESCRIPTION
This module exposes the `export` function, allowing users to write data to a location retrievable by the test sequencer using the protected function: `_get_most_recent_data()`. The Test Sequencer can also utilize `_set_output_loc()` to specify a location for exporting data to a test using an ID